### PR TITLE
[release-0.16] 🏃 Make client.MatchingLabels faster

### DIFF
--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -210,6 +211,9 @@ func (c *multiNamespaceCache) Get(ctx context.Context, key client.ObjectKey, obj
 
 	cache, ok := c.namespaceToCache[key.Namespace]
 	if !ok {
+		if global, hasGlobal := c.namespaceToCache[metav1.NamespaceAll]; hasGlobal {
+			return global.Get(ctx, key, obj, opts...)
+		}
 		return fmt.Errorf("unable to get: %v because of unknown namespace for the cache", key)
 	}
 	return cache.Get(ctx, key, obj, opts...)

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -514,7 +514,8 @@ type MatchingLabels map[string]string
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid reserializing this over and over?
 	if opts.LabelSelector == nil {
-		opts.LabelSelector = labels.NewSelector()
+		opts.LabelSelector = labels.SelectorFromValidatedSet(map[string]string(m))
+		return
 	}
 	// If there's already a selector, we need to AND the two together.
 	noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -237,6 +237,19 @@ var _ = Describe("MatchingLabels", func() {
 		expectedErrMsg := `values[0][k]: Invalid value: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui": must be no more than 63 characters`
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
+
+	It("Should add matchingLabels to existing selector", func() {
+		listOpts := &client.ListOptions{}
+
+		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
+		matchingLabels2 := client.MatchingLabels(map[string]string{"k2": "v2"})
+
+		matchingLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v"))
+
+		matchingLabels2.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,k2=v2"))
+	})
 })
 
 var _ = Describe("FieldOwner", func() {
@@ -290,5 +303,37 @@ var _ = Describe("ForceOwnership", func() {
 		t := client.ForceOwnership
 		t.ApplyToSubResourcePatch(o)
 		Expect(*o.Force).To(BeTrue())
+	})
+})
+
+var _ = Describe("HasLabels", func() {
+	It("Should produce hasLabels in given order", func() {
+		listOpts := &client.ListOptions{}
+
+		hasLabels := client.HasLabels([]string{"labelApe", "labelFox"})
+		hasLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
+	})
+
+	It("Should add hasLabels to existing hasLabels selector", func() {
+		listOpts := &client.ListOptions{}
+
+		hasLabel := client.HasLabels([]string{"labelApe"})
+		hasLabel.ApplyToList(listOpts)
+
+		hasOtherLabel := client.HasLabels([]string{"labelFox"})
+		hasOtherLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
+	})
+
+	It("Should add hasLabels to existing matchingLabels", func() {
+		listOpts := &client.ListOptions{}
+
+		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
+		matchingLabels.ApplyToList(listOpts)
+
+		hasLabel := client.HasLabels([]string{"labelApe"})
+		hasLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,labelApe"))
 	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Carries the upstream commit that fixes the client.MatchingLabels performance regression we were seeing in various product codebases. This also picks up another upstream commit that has landed in the release-0.16 branch since this branch was last created:

```bash
$ git diff upstream/release-0.16
diff --git a/pkg/client/options.go b/pkg/client/options.go
index d81bf25d..ee6489b7 100644
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -514,7 +514,8 @@ type MatchingLabels map[string]string
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
        // TODO(directxman12): can we avoid reserializing this over and over?
        if opts.LabelSelector == nil {
-               opts.LabelSelector = labels.NewSelector()
+               opts.LabelSelector = labels.SelectorFromValidatedSet(map[string]string(m))
+               return
        }
        // If there's already a selector, we need to AND the two together.
        noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))
```

Now, the only differences between the upstream and downstream release-0.16 branches are we picked up a commit that hasn't been backported.
